### PR TITLE
1.18.2 Support + Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
  - Chat log
  - Chat messages Module
  - Auto reconnect
- - Supported server versions: `1.8 - 1.18.1`
+ - Supported server versions: `1.8 - 1.18.2`
  
  ### License
  [MIT](https://github.com/Arny4/Afk-Bot/blob/main/LICENSE)

--- a/bot.js
+++ b/bot.js
@@ -1,102 +1,115 @@
-const mineflayer = require('mineflayer')
-const Movements = require('mineflayer-pathfinder').Movements
-const pathfinder = require('mineflayer-pathfinder').pathfinder
-const { GoalBlock} = require('mineflayer-pathfinder').goals
+const mineflayer = require('mineflayer');
+const Movements = require('mineflayer-pathfinder').Movements;
+const pathfinder = require('mineflayer-pathfinder').pathfinder;
+const { GoalBlock } = require('mineflayer-pathfinder').goals;
 
 const config = require('./settings.json');
 
-function createBot () {
-  const bot = mineflayer.createBot({
+function createBot() {
+   const bot = mineflayer.createBot({
       username: config['bot-account']['username'],
       password: config['bot-account']['password'],
       auth: config['bot-account']['type'],
       host: config.server.ip,
       port: config.server.port,
-      version: config.server.version
-  })
+      version: config.server.version,
+   });
 
-  bot.loadPlugin(pathfinder)
-  const mcData = require('minecraft-data')(bot.version)
-  const defaultMove = new Movements(bot, mcData)
-  bot.settings.colorsEnabled = false
+   bot.loadPlugin(pathfinder);
+   const mcData = require('minecraft-data')(bot.version);
+   const defaultMove = new Movements(bot, mcData);
+   bot.settings.colorsEnabled = false;
 
-  bot.once("spawn", function(){
-      console.log("\x1b[33m[BotLog] Bot joined to the server", '\x1b[0m')
+   bot.once('spawn', () => {
+      console.log('\x1b[33m[BotLog] Bot joined to the server', '\x1b[0m');
 
-      if(config.utils['auto-auth'].enabled){
-        console.log("[INFO] Started auto-auth module")
+      if (config.utils['auto-auth'].enabled) {
+         console.log('[INFO] Started auto-auth module');
 
-          var password = config.utils['auto-auth'].password
-          setTimeout(function() {
-              bot.chat(`/register ${password} ${password}`)
-              bot.chat(`/login ${password}`)
-          }, 500);
+         var password = config.utils['auto-auth'].password;
+         setTimeout(() => {
+            bot.chat(`/register ${password} ${password}`);
+            bot.chat(`/login ${password}`);
+         }, 500);
 
-          console.log(`[Auth] Authentification commands executed.`)
+         console.log(`[Auth] Authentification commands executed.`);
       }
 
-      if(config.utils['chat-messages'].enabled){
-        console.log("[INFO] Started chat-messages module")
-        var messages = config.utils['chat-messages']['messages']
+      if (config.utils['chat-messages'].enabled) {
+         console.log('[INFO] Started chat-messages module');
+         var messages = config.utils['chat-messages']['messages'];
 
-          if(config.utils['chat-messages'].repeat){
-            var delay = config.utils['chat-messages']['repeat-delay']
-            let i = 0
+         if (config.utils['chat-messages'].repeat) {
+            var delay = config.utils['chat-messages']['repeat-delay'];
+            let i = 0;
 
             let msg_timer = setInterval(() => {
-                bot.chat(`${messages[i]}`)
+               bot.chat(`${messages[i]}`);
 
-                if(i+1 == messages.length){
-                    i = 0
-                } else i++
-            }, delay * 1000)
-          } else {
-              messages.forEach(function(msg){
-                  bot.chat(msg)
-              })
-        }
+               if (i + 1 == messages.length) {
+                  i = 0;
+               } else i++;
+            }, delay * 1000);
+         } else {
+            messages.forEach((msg) => {
+               bot.chat(msg);
+            });
+         }
       }
-      
 
-      const pos = config.position
+      const pos = config.position;
 
-      if (config.position.enabled){
-          console.log(`\x1b[32m[BotLog] Starting moving to target location (${pos.x}, ${pos.y}, ${pos.z})\x1b[0m`)
-          bot.pathfinder.setMovements(defaultMove)
-          bot.pathfinder.setGoal(new GoalBlock(pos.x, pos.y, pos.z))
+      if (config.position.enabled) {
+         console.log(
+            `\x1b[32m[BotLog] Starting moving to target location (${pos.x}, ${pos.y}, ${pos.z})\x1b[0m`
+         );
+         bot.pathfinder.setMovements(defaultMove);
+         bot.pathfinder.setGoal(new GoalBlock(pos.x, pos.y, pos.z));
       }
-      
-      if(config.utils['anti-afk'].enabled){
-        bot.setControlState('jump', true)
-        if(config.utils['anti-afk'].sneak){
-            bot.setControlState('sneak', true)
-        }
+
+      if (config.utils['anti-afk'].enabled) {
+         bot.setControlState('jump', true);
+         if (config.utils['anti-afk'].sneak) {
+            bot.setControlState('sneak', true);
+         }
       }
-  })
+   });
 
-  bot.on("chat", function(username, message){
-      if(config.utils['chat-log']){
-          console.log(`[ChatLog] <${username}> ${message}`)
+   bot.on('chat', (username, message) => {
+      if (config.utils['chat-log']) {
+         console.log(`[ChatLog] <${username}> ${message}`);
       }
-  })
+   });
 
-  bot.on("goal_reached", function(){
-      console.log(`\x1b[32m[BotLog] Bot arrived to target location. ${bot.entity.position}\x1b[0m`)
-  })
+   bot.on('goal_reached', () => {
+      console.log(
+         `\x1b[32m[BotLog] Bot arrived to target location. ${bot.entity.position}\x1b[0m`
+      );
+   });
 
-  bot.on("death", function(){
-      console.log(`\x1b[33m[BotLog] Bot has been died and was respawned ${bot.entity.position}`, '\x1b[0m')
-  })
+   bot.on('death', () => {
+      console.log(
+         `\x1b[33m[BotLog] Bot has been died and was respawned ${bot.entity.position}`,
+         '\x1b[0m'
+      );
+   });
 
-  if(config.utils['auto-reconnect']){
-      bot.on('end', function(){
-        createBot()
-      })
-  }
+   if (config.utils['auto-reconnect']) {
+      bot.on('end', () => {
+         createBot();
+      });
+   }
 
-  bot.on('kicked', (reason) => console.log('\x1b[33m',`[BotLog] Bot was kicked from the server. Reason: \n${reason}`, '\x1b[0m'))
-  bot.on('error', err => console.log(`\x1b[31m[ERROR] ${err.message}`, '\x1b[0m'))
-
+   bot.on('kicked', (reason) =>
+      console.log(
+         '\x1b[33m',
+         `[BotLog] Bot was kicked from the server. Reason: \n${reason}`,
+         '\x1b[0m'
+      )
+   );
+   bot.on('error', (err) =>
+      console.log(`\x1b[31m[ERROR] ${err.message}`, '\x1b[0m')
+   );
 }
 
-createBot()
+createBot();

--- a/bot.js
+++ b/bot.js
@@ -96,7 +96,9 @@ function createBot() {
 
    if (config.utils['auto-reconnect']) {
       bot.on('end', () => {
-         createBot();
+         setTimeout(() => {
+             createBot
+         }, config.utils['auto-recconect-delay']);
       });
    }
 

--- a/bot.js
+++ b/bot.js
@@ -97,7 +97,7 @@ function createBot() {
    if (config.utils['auto-reconnect']) {
       bot.on('end', () => {
          setTimeout(() => {
-             createBot
+            createBot();
          }, config.utils['auto-recconect-delay']);
       });
    }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
-        "mineflayer": "^3.15.0",
+        "mineflayer": "^4.1.0",
         "mineflayer-pathfinder": "^1.9.1"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-4.5.1.tgz",
-      "integrity": "sha512-/i5dXM+QAtO+6atYd5oHGBAx48EGSISkXNXViheliOQe+SIFMDo3gSq3lL54W0suOSAsVPws3XnTaIHlla0PIQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-6.1.0.tgz",
+      "integrity": "sha512-IGjAHttOgKDPQr0Qxx1NjABR635ZNuN7LHjxI0Y7SEA2thcaRGTccy+oaXTFabM/rZLt4F2VrPKUX4BnR9hW9g==",
       "dependencies": {
         "debug": "^4.1.1"
       },
@@ -25,12 +25,13 @@
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.3.0.tgz",
-      "integrity": "sha512-BM5S5sMB6N0aPux4l85NnRNO/5/G+w3oT+JtLbMDBsc/aUxLVYoWMmxVECrYzlQRm5QZzFWRo04Rv5AnAF7z2g==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.7.0.tgz",
+      "integrity": "sha512-qDkW+Z4b0SGkkYrM1x+0s5WJ3z96vgiNZ20iwpmtCUHVfSrDiGFB8s8REKVaz7JZJi2L1s0vQRbUahly8EoGnw==",
       "dependencies": {
-        "@azure/msal-common": "^4.5.0",
-        "axios": "^0.21.1",
+        "@azure/msal-common": "^6.1.0",
+        "axios": "^0.21.4",
+        "https-proxy-agent": "^5.0.0",
         "jsonwebtoken": "^8.5.1",
         "uuid": "^8.3.0"
       },
@@ -56,6 +57,17 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
       "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ=="
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
     },
     "node_modules/ajv": {
       "version": "6.12.6",
@@ -104,9 +116,9 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -148,9 +160,9 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.8",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
-      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==",
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
       "funding": [
         {
           "type": "individual",
@@ -166,10 +178,30 @@
         }
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/jose": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.6.0.tgz",
+      "integrity": "sha512-0hNAkhMBNi4soKSAX4zYOFV+aqJlEz/4j4fregvasJzEVtjDChvWqRjPvHwLqr5hx28Ayr6bsOs1Kuj87V0O8w==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -272,9 +304,9 @@
       "integrity": "sha512-cYYBbT3b84hTEHssWE6OmsuqF/NiLXE2RGK9Sc9SwwE9kMoKrbaUAJtKs6ucd0FFgZjXE1Wm3hoGEEYas0N6EA=="
     },
     "node_modules/minecraft-data": {
-      "version": "2.109.0",
-      "resolved": "https://registry.npmjs.org/minecraft-data/-/minecraft-data-2.109.0.tgz",
-      "integrity": "sha512-gmWR/bUU/tl+GDiI2GDHy96rN0f6N4RfyLpJ34/RNf1nqJzaxtZ+OZuleidJxpi40EPoZLBgJUh9Biv1u6exvg=="
+      "version": "2.220.0",
+      "resolved": "https://registry.npmjs.org/minecraft-data/-/minecraft-data-2.220.0.tgz",
+      "integrity": "sha512-6/1TxrX9jf8z8aRxWtB9IiDy6O3t6Yor/qGxCDB8ibahf/Ss5HNaPjjjjATLrdT2KrIWywv5oc4eSZ2bfXlDmQ=="
     },
     "node_modules/minecraft-folder-path": {
       "version": "1.2.0",
@@ -282,43 +314,50 @@
       "integrity": "sha512-qaUSbKWoOsH9brn0JQuBhxNAzTDMwrOXorwuRxdJKKKDYvZhtml+6GVCUrY5HRiEsieBEjCUnhVpDuQiKsiFaw=="
     },
     "node_modules/minecraft-protocol": {
-      "version": "1.26.5",
-      "resolved": "https://registry.npmjs.org/minecraft-protocol/-/minecraft-protocol-1.26.5.tgz",
-      "integrity": "sha512-PKYUeyG+mb4MkwWbX4XrQ5SG5B4PDE6XF3Fm+z1iRwGck23DFVV3hxRHkUqBUxe0TxKrOXKGzhvT+vn541QHOw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/minecraft-protocol/-/minecraft-protocol-1.32.0.tgz",
+      "integrity": "sha512-KIg/SnKagSe2GtVjvWealobTkC1VLPCRYpzIZd4l+rbo3fND1e1NBmfZVsawbByYwK6/STKODkMJgk763FejTQ==",
       "dependencies": {
-        "@azure/msal-node": "^1.0.0-beta.3",
-        "@xboxreplay/xboxlive-auth": "^3.3.3",
         "aes-js": "^3.1.2",
         "buffer-equal": "^1.0.0",
-        "debug": "^4.1.0",
+        "debug": "^4.3.2",
         "endian-toggle": "^0.0.0",
         "lodash.get": "^4.1.2",
         "lodash.merge": "^4.3.0",
-        "minecraft-data": "^2.85.1",
-        "minecraft-folder-path": "^1.1.0",
+        "minecraft-data": "^2.109.0",
+        "minecraft-folder-path": "^1.2.0",
         "node-fetch": "^2.6.1",
         "node-rsa": "^0.4.2",
-        "prismarine-nbt": "^1.3.0",
+        "prismarine-auth": "^1.1.0",
+        "prismarine-nbt": "^2.0.0",
         "protodef": "^1.8.0",
         "readable-stream": "^3.0.6",
         "uuid-1345": "^1.0.1",
         "yggdrasil": "^1.4.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=14"
+      }
+    },
+    "node_modules/minecraft-protocol/node_modules/prismarine-nbt": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/prismarine-nbt/-/prismarine-nbt-2.2.0.tgz",
+      "integrity": "sha512-6UgW9gkurSs2+L6el6bVHvK5BmfAdMv9ixY+zn4GSaTSOzuWumspErpStxo9RbeixmVq66dd0OQu1tHYXVkX8g==",
+      "dependencies": {
+        "protodef": "^1.9.0"
       }
     },
     "node_modules/mineflayer": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/mineflayer/-/mineflayer-3.15.0.tgz",
-      "integrity": "sha512-eognd3MOrC72W2TSRYhyWRw7FNSzEQd91o2Rl10nuk+yLBFaOsI3ZKKpBK7VBnMCuioHDGFHe2DhMGIRTxAGWQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mineflayer/-/mineflayer-4.1.0.tgz",
+      "integrity": "sha512-Av6qote/cmWrlCB4WArleKHmh8zrU4SYOygdLVi9OglUbsUnaIGPkbSrneL0vhW/io+1WR6/OjHts8W8Hc73Dg==",
       "dependencies": {
-        "minecraft-data": "^2.109.0",
-        "minecraft-protocol": "^1.26.5",
+        "minecraft-data": "^2.114.1",
+        "minecraft-protocol": "^1.31.0",
         "prismarine-biome": "^1.1.1",
-        "prismarine-block": "^1.10.3",
+        "prismarine-block": "^1.13.1",
         "prismarine-chat": "^1.3.3",
-        "prismarine-chunk": "^1.28.1",
+        "prismarine-chunk": "^1.29.0",
         "prismarine-entity": "^2.0.0",
         "prismarine-item": "^1.11.0",
         "prismarine-nbt": "^2.0.0",
@@ -327,7 +366,7 @@
         "prismarine-windows": "^2.4.2",
         "prismarine-world": "^3.6.0",
         "protodef": "^1.14.0",
-        "typed-emitter": "^2.0.0",
+        "typed-emitter": "^1.0.0",
         "vec3": "^0.1.7"
       },
       "engines": {
@@ -357,9 +396,9 @@
       }
     },
     "node_modules/mineflayer/node_modules/prismarine-nbt": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/prismarine-nbt/-/prismarine-nbt-2.0.0.tgz",
-      "integrity": "sha512-Q+HzmnW5BhiIGk++vJbRIr5ekSt51uLLEzBA4a0Bt+/6Ohh2xIL9O/i3v9vMSo0WcnyjGm1HA/wS4+zDKrLUKQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/prismarine-nbt/-/prismarine-nbt-2.2.0.tgz",
+      "integrity": "sha512-6UgW9gkurSs2+L6el6bVHvK5BmfAdMv9ixY+zn4GSaTSOzuWumspErpStxo9RbeixmVq66dd0OQu1tHYXVkX8g==",
       "dependencies": {
         "protodef": "^1.9.0"
       }
@@ -430,24 +469,50 @@
         "asn1": "0.2.3"
       }
     },
+    "node_modules/prismarine-auth": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prismarine-auth/-/prismarine-auth-1.5.0.tgz",
+      "integrity": "sha512-b3vDr53ac1mdp2AyRDVVKGp3eqXKKNXuZZ0Cxjc2HzVxhurPhRBETOM3/nrgGr9yt7FdI2+/60w7w5B55crJiA==",
+      "dependencies": {
+        "@azure/msal-node": "^1.1.0",
+        "@xboxreplay/xboxlive-auth": "^3.3.3",
+        "debug": "^4.3.3",
+        "jose": "^4.1.4",
+        "node-fetch": "^2.6.1",
+        "smart-buffer": "^4.1.0",
+        "uuid-1345": "^1.0.2"
+      }
+    },
     "node_modules/prismarine-biome": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/prismarine-biome/-/prismarine-biome-1.1.1.tgz",
-      "integrity": "sha512-JkX1CcIDR538j5Qj3pbLCTB2LsGukNOudWbk4niQ93a3fItLVJkPnY9H3/uxpVz2PIQxhmaAXVRaYWj6M9C2Bw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prismarine-biome/-/prismarine-biome-1.2.1.tgz",
+      "integrity": "sha512-bfClX/NKMDkmA//0o1za3Nmcd1krmnv8hmjIYRS435dQvDJ2MKmCkDGUJ5CTy2epB976CDgzj9h1JT1a8MUn1Q==",
       "peerDependencies": {
-        "minecraft-data": "^2.0.0"
+        "minecraft-data": "^2.0.0",
+        "prismarine-registry": "^1.1.0"
       }
     },
     "node_modules/prismarine-block": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/prismarine-block/-/prismarine-block-1.10.3.tgz",
-      "integrity": "sha512-RFJiXmzGwmNPGeUkNSzxAGRcWkIrtQOVT4j0KcBjol3ae117DgTZKmJqqqbW78ip6lAmwjwy6s6cyiiDxzEKYA==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/prismarine-block/-/prismarine-block-1.15.0.tgz",
+      "integrity": "sha512-h9vJK9N2sg5FaZbWf4oBQK+TWqFlDc7grRUPRpGt8Lv6948x2u6JYgcSrRGY1LUsyR8B1ii/M8b686GEU6VPbA==",
       "dependencies": {
         "prismarine-biome": "^1.1.0",
-        "prismarine-item": "^1.10.1"
+        "prismarine-chat": "^1.5.0",
+        "prismarine-item": "^1.10.1",
+        "prismarine-nbt": "^2.0.0",
+        "prismarine-registry": "^1.1.0"
       },
       "peerDependencies": {
-        "minecraft-data": "^2.62.1"
+        "minecraft-data": "^2.113.1"
+      }
+    },
+    "node_modules/prismarine-block/node_modules/prismarine-nbt": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/prismarine-nbt/-/prismarine-nbt-2.2.0.tgz",
+      "integrity": "sha512-6UgW9gkurSs2+L6el6bVHvK5BmfAdMv9ixY+zn4GSaTSOzuWumspErpStxo9RbeixmVq66dd0OQu1tHYXVkX8g==",
+      "dependencies": {
+        "protodef": "^1.9.0"
       }
     },
     "node_modules/prismarine-chat": {
@@ -471,15 +536,18 @@
       }
     },
     "node_modules/prismarine-chunk": {
-      "version": "1.28.1",
-      "resolved": "https://registry.npmjs.org/prismarine-chunk/-/prismarine-chunk-1.28.1.tgz",
-      "integrity": "sha512-bJHOuFt26l+HQIYEfLCD5ee/oRjlU7U4PfVmfqyRDczpzBLhqyLX563hhIA/2s9q2RPhZ+Kd3f3ltBuFeMTKJg==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismarine-chunk/-/prismarine-chunk-1.30.0.tgz",
+      "integrity": "sha512-hq8Vtslm79nI/KnMWwbd5nHEUURF4kkIW1UPjNI5YzwFKJcb8Z6kRkozCxFr8L1Qk/A7fxdKGHaRxTMZeor+1g==",
       "dependencies": {
-        "minecraft-data": "^2.61.0",
-        "prismarine-block": "^1.2.0",
+        "minecraft-data": "^2.113.1",
+        "prismarine-biome": "^1.2.0",
+        "prismarine-block": "^1.14.1",
+        "prismarine-registry": "^1.1.0",
         "smart-buffer": "^4.1.0",
         "uint4": "^0.1.2",
-        "vec3": "^0.1.3"
+        "vec3": "^0.1.3",
+        "xxhash-wasm": "^0.4.2"
       },
       "engines": {
         "node": ">=14"
@@ -529,6 +597,23 @@
       "integrity": "sha512-eFmriEWoe6S6OSVbOJnsXpaBuzeIzjaGymDUTCtrOu80734NWKI7outdLI6R2ztJ+f2PFIkFmpkazAdScStGNA==",
       "peerDependencies": {
         "minecraft-data": "^2.0.0"
+      }
+    },
+    "node_modules/prismarine-registry": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/prismarine-registry/-/prismarine-registry-1.1.0.tgz",
+      "integrity": "sha512-zCI4LRRGATsqz2KQ6JKbgWMCTAsYcSDq/GuUQohS5XVW223byzZNHqwsqZLBScAvLnvWmfhe/Ok/UgJcrXxfRw==",
+      "dependencies": {
+        "minecraft-data": "^2.106.0",
+        "prismarine-nbt": "^2.0.0"
+      }
+    },
+    "node_modules/prismarine-registry/node_modules/prismarine-nbt": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/prismarine-nbt/-/prismarine-nbt-2.2.0.tgz",
+      "integrity": "sha512-6UgW9gkurSs2+L6el6bVHvK5BmfAdMv9ixY+zn4GSaTSOzuWumspErpStxo9RbeixmVq66dd0OQu1tHYXVkX8g==",
+      "dependencies": {
+        "protodef": "^1.9.0"
       }
     },
     "node_modules/prismarine-windows": {
@@ -622,15 +707,6 @@
         "node": ">=0.12"
       }
     },
-    "node_modules/rxjs": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.2.tgz",
-      "integrity": "sha512-PwDt186XaL3QN5qXj/H9DGyHhP3/RYYgZZwqBv9Tv8rsAaiwFH1IsJJlcgD37J7UW5a6O67qX0KWKS3/pu0m4w==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -685,19 +761,10 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
-    "node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-      "optional": true
-    },
     "node_modules/typed-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
-      "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
-      "optionalDependencies": {
-        "rxjs": "*"
-      }
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-1.4.0.tgz",
+      "integrity": "sha512-weBmoo3HhpKGgLBOYwe8EB31CzDFuaK7CCL+axXhUYhn4jo6DSkHnbefboCF5i4DQ2aMFe0C/FdTWcPdObgHyg=="
     },
     "node_modules/uint4": {
       "version": "0.1.2",
@@ -752,6 +819,11 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/xxhash-wasm": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-0.4.2.tgz",
+      "integrity": "sha512-/eyHVRJQCirEkSZ1agRSCwriMhwlyUcFkXD5TPVSLP+IPzjsqMVzZwdoczLp1SoQU0R3dxz1RpIK+4YNQbCVOA=="
+    },
     "node_modules/yggdrasil": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/yggdrasil/-/yggdrasil-1.6.1.tgz",
@@ -764,20 +836,21 @@
   },
   "dependencies": {
     "@azure/msal-common": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-4.5.1.tgz",
-      "integrity": "sha512-/i5dXM+QAtO+6atYd5oHGBAx48EGSISkXNXViheliOQe+SIFMDo3gSq3lL54W0suOSAsVPws3XnTaIHlla0PIQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-6.1.0.tgz",
+      "integrity": "sha512-IGjAHttOgKDPQr0Qxx1NjABR635ZNuN7LHjxI0Y7SEA2thcaRGTccy+oaXTFabM/rZLt4F2VrPKUX4BnR9hW9g==",
       "requires": {
         "debug": "^4.1.1"
       }
     },
     "@azure/msal-node": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.3.0.tgz",
-      "integrity": "sha512-BM5S5sMB6N0aPux4l85NnRNO/5/G+w3oT+JtLbMDBsc/aUxLVYoWMmxVECrYzlQRm5QZzFWRo04Rv5AnAF7z2g==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.7.0.tgz",
+      "integrity": "sha512-qDkW+Z4b0SGkkYrM1x+0s5WJ3z96vgiNZ20iwpmtCUHVfSrDiGFB8s8REKVaz7JZJi2L1s0vQRbUahly8EoGnw==",
       "requires": {
-        "@azure/msal-common": "^4.5.0",
-        "axios": "^0.21.1",
+        "@azure/msal-common": "^6.1.0",
+        "axios": "^0.21.4",
+        "https-proxy-agent": "^5.0.0",
         "jsonwebtoken": "^8.5.1",
         "uuid": "^8.3.0"
       }
@@ -800,6 +873,14 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
       "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ=="
+    },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "requires": {
+        "debug": "4"
+      }
     },
     "ajv": {
       "version": "6.12.6",
@@ -841,9 +922,9 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "requires": {
         "ms": "2.1.2"
       }
@@ -877,14 +958,28 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "follow-redirects": {
-      "version": "1.14.8",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
-      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA=="
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
+    },
+    "https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      }
     },
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "jose": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.6.0.tgz",
+      "integrity": "sha512-0hNAkhMBNi4soKSAX4zYOFV+aqJlEz/4j4fregvasJzEVtjDChvWqRjPvHwLqr5hx28Ayr6bsOs1Kuj87V0O8w=="
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -983,9 +1078,9 @@
       "integrity": "sha512-cYYBbT3b84hTEHssWE6OmsuqF/NiLXE2RGK9Sc9SwwE9kMoKrbaUAJtKs6ucd0FFgZjXE1Wm3hoGEEYas0N6EA=="
     },
     "minecraft-data": {
-      "version": "2.109.0",
-      "resolved": "https://registry.npmjs.org/minecraft-data/-/minecraft-data-2.109.0.tgz",
-      "integrity": "sha512-gmWR/bUU/tl+GDiI2GDHy96rN0f6N4RfyLpJ34/RNf1nqJzaxtZ+OZuleidJxpi40EPoZLBgJUh9Biv1u6exvg=="
+      "version": "2.220.0",
+      "resolved": "https://registry.npmjs.org/minecraft-data/-/minecraft-data-2.220.0.tgz",
+      "integrity": "sha512-6/1TxrX9jf8z8aRxWtB9IiDy6O3t6Yor/qGxCDB8ibahf/Ss5HNaPjjjjATLrdT2KrIWywv5oc4eSZ2bfXlDmQ=="
     },
     "minecraft-folder-path": {
       "version": "1.2.0",
@@ -993,40 +1088,49 @@
       "integrity": "sha512-qaUSbKWoOsH9brn0JQuBhxNAzTDMwrOXorwuRxdJKKKDYvZhtml+6GVCUrY5HRiEsieBEjCUnhVpDuQiKsiFaw=="
     },
     "minecraft-protocol": {
-      "version": "1.26.5",
-      "resolved": "https://registry.npmjs.org/minecraft-protocol/-/minecraft-protocol-1.26.5.tgz",
-      "integrity": "sha512-PKYUeyG+mb4MkwWbX4XrQ5SG5B4PDE6XF3Fm+z1iRwGck23DFVV3hxRHkUqBUxe0TxKrOXKGzhvT+vn541QHOw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/minecraft-protocol/-/minecraft-protocol-1.32.0.tgz",
+      "integrity": "sha512-KIg/SnKagSe2GtVjvWealobTkC1VLPCRYpzIZd4l+rbo3fND1e1NBmfZVsawbByYwK6/STKODkMJgk763FejTQ==",
       "requires": {
-        "@azure/msal-node": "^1.0.0-beta.3",
-        "@xboxreplay/xboxlive-auth": "^3.3.3",
         "aes-js": "^3.1.2",
         "buffer-equal": "^1.0.0",
-        "debug": "^4.1.0",
+        "debug": "^4.3.2",
         "endian-toggle": "^0.0.0",
         "lodash.get": "^4.1.2",
         "lodash.merge": "^4.3.0",
-        "minecraft-data": "^2.85.1",
-        "minecraft-folder-path": "^1.1.0",
+        "minecraft-data": "^2.109.0",
+        "minecraft-folder-path": "^1.2.0",
         "node-fetch": "^2.6.1",
         "node-rsa": "^0.4.2",
-        "prismarine-nbt": "^1.3.0",
+        "prismarine-auth": "^1.1.0",
+        "prismarine-nbt": "^2.0.0",
         "protodef": "^1.8.0",
         "readable-stream": "^3.0.6",
         "uuid-1345": "^1.0.1",
         "yggdrasil": "^1.4.0"
+      },
+      "dependencies": {
+        "prismarine-nbt": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/prismarine-nbt/-/prismarine-nbt-2.2.0.tgz",
+          "integrity": "sha512-6UgW9gkurSs2+L6el6bVHvK5BmfAdMv9ixY+zn4GSaTSOzuWumspErpStxo9RbeixmVq66dd0OQu1tHYXVkX8g==",
+          "requires": {
+            "protodef": "^1.9.0"
+          }
+        }
       }
     },
     "mineflayer": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/mineflayer/-/mineflayer-3.15.0.tgz",
-      "integrity": "sha512-eognd3MOrC72W2TSRYhyWRw7FNSzEQd91o2Rl10nuk+yLBFaOsI3ZKKpBK7VBnMCuioHDGFHe2DhMGIRTxAGWQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mineflayer/-/mineflayer-4.1.0.tgz",
+      "integrity": "sha512-Av6qote/cmWrlCB4WArleKHmh8zrU4SYOygdLVi9OglUbsUnaIGPkbSrneL0vhW/io+1WR6/OjHts8W8Hc73Dg==",
       "requires": {
-        "minecraft-data": "^2.109.0",
-        "minecraft-protocol": "^1.26.5",
+        "minecraft-data": "^2.114.1",
+        "minecraft-protocol": "^1.31.0",
         "prismarine-biome": "^1.1.1",
-        "prismarine-block": "^1.10.3",
+        "prismarine-block": "^1.13.1",
         "prismarine-chat": "^1.3.3",
-        "prismarine-chunk": "^1.28.1",
+        "prismarine-chunk": "^1.29.0",
         "prismarine-entity": "^2.0.0",
         "prismarine-item": "^1.11.0",
         "prismarine-nbt": "^2.0.0",
@@ -1035,14 +1139,14 @@
         "prismarine-windows": "^2.4.2",
         "prismarine-world": "^3.6.0",
         "protodef": "^1.14.0",
-        "typed-emitter": "^2.0.0",
+        "typed-emitter": "^1.0.0",
         "vec3": "^0.1.7"
       },
       "dependencies": {
         "prismarine-nbt": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/prismarine-nbt/-/prismarine-nbt-2.0.0.tgz",
-          "integrity": "sha512-Q+HzmnW5BhiIGk++vJbRIr5ekSt51uLLEzBA4a0Bt+/6Ohh2xIL9O/i3v9vMSo0WcnyjGm1HA/wS4+zDKrLUKQ==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/prismarine-nbt/-/prismarine-nbt-2.2.0.tgz",
+          "integrity": "sha512-6UgW9gkurSs2+L6el6bVHvK5BmfAdMv9ixY+zn4GSaTSOzuWumspErpStxo9RbeixmVq66dd0OQu1tHYXVkX8g==",
           "requires": {
             "protodef": "^1.9.0"
           }
@@ -1118,19 +1222,46 @@
         "asn1": "0.2.3"
       }
     },
+    "prismarine-auth": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prismarine-auth/-/prismarine-auth-1.5.0.tgz",
+      "integrity": "sha512-b3vDr53ac1mdp2AyRDVVKGp3eqXKKNXuZZ0Cxjc2HzVxhurPhRBETOM3/nrgGr9yt7FdI2+/60w7w5B55crJiA==",
+      "requires": {
+        "@azure/msal-node": "^1.1.0",
+        "@xboxreplay/xboxlive-auth": "^3.3.3",
+        "debug": "^4.3.3",
+        "jose": "^4.1.4",
+        "node-fetch": "^2.6.1",
+        "smart-buffer": "^4.1.0",
+        "uuid-1345": "^1.0.2"
+      }
+    },
     "prismarine-biome": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/prismarine-biome/-/prismarine-biome-1.1.1.tgz",
-      "integrity": "sha512-JkX1CcIDR538j5Qj3pbLCTB2LsGukNOudWbk4niQ93a3fItLVJkPnY9H3/uxpVz2PIQxhmaAXVRaYWj6M9C2Bw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prismarine-biome/-/prismarine-biome-1.2.1.tgz",
+      "integrity": "sha512-bfClX/NKMDkmA//0o1za3Nmcd1krmnv8hmjIYRS435dQvDJ2MKmCkDGUJ5CTy2epB976CDgzj9h1JT1a8MUn1Q==",
       "requires": {}
     },
     "prismarine-block": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/prismarine-block/-/prismarine-block-1.10.3.tgz",
-      "integrity": "sha512-RFJiXmzGwmNPGeUkNSzxAGRcWkIrtQOVT4j0KcBjol3ae117DgTZKmJqqqbW78ip6lAmwjwy6s6cyiiDxzEKYA==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/prismarine-block/-/prismarine-block-1.15.0.tgz",
+      "integrity": "sha512-h9vJK9N2sg5FaZbWf4oBQK+TWqFlDc7grRUPRpGt8Lv6948x2u6JYgcSrRGY1LUsyR8B1ii/M8b686GEU6VPbA==",
       "requires": {
         "prismarine-biome": "^1.1.0",
-        "prismarine-item": "^1.10.1"
+        "prismarine-chat": "^1.5.0",
+        "prismarine-item": "^1.10.1",
+        "prismarine-nbt": "^2.0.0",
+        "prismarine-registry": "^1.1.0"
+      },
+      "dependencies": {
+        "prismarine-nbt": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/prismarine-nbt/-/prismarine-nbt-2.2.0.tgz",
+          "integrity": "sha512-6UgW9gkurSs2+L6el6bVHvK5BmfAdMv9ixY+zn4GSaTSOzuWumspErpStxo9RbeixmVq66dd0OQu1tHYXVkX8g==",
+          "requires": {
+            "protodef": "^1.9.0"
+          }
+        }
       }
     },
     "prismarine-chat": {
@@ -1156,15 +1287,18 @@
       }
     },
     "prismarine-chunk": {
-      "version": "1.28.1",
-      "resolved": "https://registry.npmjs.org/prismarine-chunk/-/prismarine-chunk-1.28.1.tgz",
-      "integrity": "sha512-bJHOuFt26l+HQIYEfLCD5ee/oRjlU7U4PfVmfqyRDczpzBLhqyLX563hhIA/2s9q2RPhZ+Kd3f3ltBuFeMTKJg==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismarine-chunk/-/prismarine-chunk-1.30.0.tgz",
+      "integrity": "sha512-hq8Vtslm79nI/KnMWwbd5nHEUURF4kkIW1UPjNI5YzwFKJcb8Z6kRkozCxFr8L1Qk/A7fxdKGHaRxTMZeor+1g==",
       "requires": {
-        "minecraft-data": "^2.61.0",
-        "prismarine-block": "^1.2.0",
+        "minecraft-data": "^2.113.1",
+        "prismarine-biome": "^1.2.0",
+        "prismarine-block": "^1.14.1",
+        "prismarine-registry": "^1.1.0",
         "smart-buffer": "^4.1.0",
         "uint4": "^0.1.2",
-        "vec3": "^0.1.3"
+        "vec3": "^0.1.3",
+        "xxhash-wasm": "^0.4.2"
       }
     },
     "prismarine-entity": {
@@ -1207,6 +1341,25 @@
       "resolved": "https://registry.npmjs.org/prismarine-recipe/-/prismarine-recipe-1.1.0.tgz",
       "integrity": "sha512-eFmriEWoe6S6OSVbOJnsXpaBuzeIzjaGymDUTCtrOu80734NWKI7outdLI6R2ztJ+f2PFIkFmpkazAdScStGNA==",
       "requires": {}
+    },
+    "prismarine-registry": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/prismarine-registry/-/prismarine-registry-1.1.0.tgz",
+      "integrity": "sha512-zCI4LRRGATsqz2KQ6JKbgWMCTAsYcSDq/GuUQohS5XVW223byzZNHqwsqZLBScAvLnvWmfhe/Ok/UgJcrXxfRw==",
+      "requires": {
+        "minecraft-data": "^2.106.0",
+        "prismarine-nbt": "^2.0.0"
+      },
+      "dependencies": {
+        "prismarine-nbt": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/prismarine-nbt/-/prismarine-nbt-2.2.0.tgz",
+          "integrity": "sha512-6UgW9gkurSs2+L6el6bVHvK5BmfAdMv9ixY+zn4GSaTSOzuWumspErpStxo9RbeixmVq66dd0OQu1tHYXVkX8g==",
+          "requires": {
+            "protodef": "^1.9.0"
+          }
+        }
+      }
     },
     "prismarine-windows": {
       "version": "2.4.3",
@@ -1278,15 +1431,6 @@
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
     },
-    "rxjs": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.2.tgz",
-      "integrity": "sha512-PwDt186XaL3QN5qXj/H9DGyHhP3/RYYgZZwqBv9Tv8rsAaiwFH1IsJJlcgD37J7UW5a6O67qX0KWKS3/pu0m4w==",
-      "optional": true,
-      "requires": {
-        "tslib": "^2.1.0"
-      }
-    },
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -1320,19 +1464,10 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
-    "tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-      "optional": true
-    },
     "typed-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
-      "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
-      "requires": {
-        "rxjs": "*"
-      }
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-1.4.0.tgz",
+      "integrity": "sha512-weBmoo3HhpKGgLBOYwe8EB31CzDFuaK7CCL+axXhUYhn4jo6DSkHnbefboCF5i4DQ2aMFe0C/FdTWcPdObgHyg=="
     },
     "uint4": {
       "version": "0.1.2",
@@ -1383,6 +1518,11 @@
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
       }
+    },
+    "xxhash-wasm": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-0.4.2.tgz",
+      "integrity": "sha512-/eyHVRJQCirEkSZ1agRSCwriMhwlyUcFkXD5TPVSLP+IPzjsqMVzZwdoczLp1SoQU0R3dxz1RpIK+4YNQbCVOA=="
     },
     "yggdrasil": {
       "version": "1.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "mineflayer": "^4.1.0",
-        "mineflayer-pathfinder": "^1.9.1"
+        "mineflayer-pathfinder": "^1.10.0"
       }
     },
     "node_modules/@azure/msal-common": {
@@ -374,9 +374,9 @@
       }
     },
     "node_modules/mineflayer-pathfinder": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/mineflayer-pathfinder/-/mineflayer-pathfinder-1.9.1.tgz",
-      "integrity": "sha512-4mslXjn7NU5NNXUsYfieQwaycUzAg9Henzqs/ZaBT1Hc53VwmsQK1M2TEqFCOwdU8Q6Urk0LcY/87SBPIz8BZQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/mineflayer-pathfinder/-/mineflayer-pathfinder-1.10.0.tgz",
+      "integrity": "sha512-2OZYoDv7GqiEKK33ql8BQeFIb8jvRo+GSTWE1ZP7BABH0w78WYLhAdKhMuUKfUFWfz/H5SnnYDDV/Zhvy0ReBg==",
       "dependencies": {
         "minecraft-data": "^2.75.0",
         "prismarine-block": "^1.7.3",
@@ -1154,9 +1154,9 @@
       }
     },
     "mineflayer-pathfinder": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/mineflayer-pathfinder/-/mineflayer-pathfinder-1.9.1.tgz",
-      "integrity": "sha512-4mslXjn7NU5NNXUsYfieQwaycUzAg9Henzqs/ZaBT1Hc53VwmsQK1M2TEqFCOwdU8Q6Urk0LcY/87SBPIz8BZQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/mineflayer-pathfinder/-/mineflayer-pathfinder-1.10.0.tgz",
+      "integrity": "sha512-2OZYoDv7GqiEKK33ql8BQeFIb8jvRo+GSTWE1ZP7BABH0w78WYLhAdKhMuUKfUFWfz/H5SnnYDDV/Zhvy0ReBg==",
       "requires": {
         "minecraft-data": "^2.75.0",
         "prismarine-block": "^1.7.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "mineflayer": "^4.1.0",
-        "mineflayer-pathfinder": "^1.10.0"
+        "mineflayer-pathfinder": "^1.9.0"
       }
     },
     "node_modules/@azure/msal-common": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
   "license": "MIT",
   "dependencies": {
     "mineflayer": "^4.1.0",
-    "mineflayer-pathfinder": "^1.10.0"
+    "mineflayer-pathfinder": "^1.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
   "license": "MIT",
   "dependencies": {
     "mineflayer": "^4.1.0",
-    "mineflayer-pathfinder": "^1.9.1"
+    "mineflayer-pathfinder": "^1.10.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "urFate",
   "license": "MIT",
   "dependencies": {
-    "mineflayer": "^3.15.0",
+    "mineflayer": "^4.1.0",
     "mineflayer-pathfinder": "^1.9.1"
   }
 }

--- a/settings.json
+++ b/settings.json
@@ -1,48 +1,49 @@
 {
-    "bot-account":{ 
-        "username": "bot",
-        "password": "",
-        "type": "mojang"
-    },
+   "bot-account": {
+      "username": "bot",
+      "password": "",
+      "type": "mojang"
+   },
 
-    "server":{
-        "ip": "localhost",
-        "port": 25565,
-        "version": "1.17.1"
-    },
+   "server": {
+      "ip": "localhost",
+      "port": 25565,
+      "version": "1.17.1"
+   },
 
-    "position":{
-        "enabled": false,
-        "x": 0,
-        "y": 0,
-        "z": 0
-    },
+   "position": {
+      "enabled": false,
+      "x": 0,
+      "y": 0,
+      "z": 0
+   },
 
-    "utils":{
-        "auto-auth":{
-            "enabled": false,
-            "password": "12345678"
-        },
+   "utils": {
+      "auto-auth": {
+         "enabled": false,
+         "password": "12345678"
+      },
 
-        "anti-afk":{
-            "enabled": false,
-            "sneak": false
-        },
+      "anti-afk": {
+         "enabled": false,
+         "sneak": false
+      },
 
-        "chat-messages":{
-            "enabled": false,
-            "repeat": true,
-            "repeat-delay": 60,
+      "chat-messages": {
+         "enabled": false,
+         "repeat": true,
+         "repeat-delay": 60,
 
-            "messages": [
-                "I'm a regular player ", 
-                "My owner is urFate_ ", 
-                "I want be alone ", 
-                "Visit my GitHub page! (urFate/Afk-Bot)"
-            ]
-        },
+         "messages": [
+            "I'm a regular player ",
+            "My owner is urFate_ ",
+            "I want be alone ",
+            "Visit my GitHub page! (urFate/Afk-Bot)"
+         ]
+      },
 
-        "chat-log": true,
-        "auto-reconnect": false
-    }
+      "chat-log": true,
+      "auto-reconnect": false,
+      "auto-recconect-delay": 5000
+   }
 }

--- a/settings.json
+++ b/settings.json
@@ -1,49 +1,49 @@
 {
-   "bot-account": {
-      "username": "bot",
-      "password": "",
-      "type": "mojang"
-   },
+  "bot-account": {
+    "username": "bot",
+    "password": "",
+    "type": "mojang"
+  },
 
-   "server": {
-      "ip": "localhost",
-      "port": 25565,
-      "version": "1.17.1"
-   },
+  "server": {
+    "ip": "localhost",
+    "port": 25565,
+    "version": "1.17.1"
+  },
 
-   "position": {
+  "position": {
+    "enabled": false,
+    "x": 0,
+    "y": 0,
+    "z": 0
+  },
+
+  "utils": {
+    "auto-auth": {
       "enabled": false,
-      "x": 0,
-      "y": 0,
-      "z": 0
-   },
+      "password": "12345678"
+    },
 
-   "utils": {
-      "auto-auth": {
-         "enabled": false,
-         "password": "12345678"
-      },
+    "anti-afk": {
+      "enabled": false,
+      "sneak": false
+    },
 
-      "anti-afk": {
-         "enabled": false,
-         "sneak": false
-      },
+    "chat-messages": {
+      "enabled": false,
+      "repeat": true,
+      "repeat-delay": 60,
 
-      "chat-messages": {
-         "enabled": false,
-         "repeat": true,
-         "repeat-delay": 60,
+      "messages": [
+        "I'm a regular player ",
+        "My owner is urFate_ ",
+        "I want be alone ",
+        "Visit my GitHub page! (urFate/Afk-Bot)"
+      ]
+    },
 
-         "messages": [
-            "I'm a regular player ",
-            "My owner is urFate_ ",
-            "I want be alone ",
-            "Visit my GitHub page! (urFate/Afk-Bot)"
-         ]
-      },
-
-      "chat-log": true,
-      "auto-reconnect": false,
-      "auto-recconect-delay": 5000
-   }
+    "chat-log": true,
+    "auto-reconnect": false,
+    "auto-recconect-delay": 5000
+  }
 }


### PR DESCRIPTION
I added some improvements to this bot :)

Update Mineflayer to version 4.1.0 (For 1.18.2 Support)
General code formatting (ES6-ify Callback functions, semi-colons, etc)
Added a feature to delay the auto-recconect action  (Customizable in settings.json), not doing this can sometimes lead to [this](https://i.imgur.com/F4c4ihu.png).

All modules (Path-finding, auto-auth, anti-afk and chat-messages) were tested in a PaperMC 1.18.2-241 Server and encountered no issues.